### PR TITLE
fix: initialize React Devtools before React Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ __Check the base [`webpack.config.js`](./templates/webpack.config.js) template, 
 - [x] Development server with Remote JS Debugging, Source Map symbolication and HMR support
 - [x] Hot Module Replacement + React Refresh support
 - [x] Reloading application from CLI
-- [x] Flipper support (tested features: Crash Reporter, Logs, Layout, Network, React DevTools with caveat [facebook/react#20377](https://github.com/facebook/react/issues/20377))
+- [x] Flipper support (tested features: Crash Reporter, Logs, Layout, Network, React DevTools)
 
 ### Planned features
 
-- [ ] Missing Flipper features support (working HMR/React Refresh with React DevTools, Images and Databases) 
 - [ ] Hermes support
 - [ ] `webpack-init` command
 - [ ] Web dashboard with logs, compilation statues, bundle explorer, visualizations and more
@@ -164,12 +163,6 @@ This expected and there's little we can do about it. The stack trace is still co
 
 If you encounter such situation, and you need to get the precise stack trace, you can do a full reload
 and reproduce the error or `console.log`/`console.error` call.
-
-#### 3. React DevTools don't work with Hot Module Replacement / React Refresh
-
-The issue was reported here: [facebook/react#20377](https://github.com/facebook/react/issues/20377). Because we use similar solutions to implement React Refresh, we are affected by the same issue.
-
-For now the workaround is to temporarily disable HMR when debugging with Flipper or React DevTools, then switching it back when Flipper/React DevTools are disconnected.
 
 ## Made with ❤️ at Callstack
 

--- a/examples/TesterApp/package-lock.json
+++ b/examples/TesterApp/package-lock.json
@@ -5144,6 +5144,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -5782,6 +5783,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/server/DevServerProxy.ts
+++ b/src/server/DevServerProxy.ts
@@ -277,6 +277,8 @@ export class DevServerProxy extends BaseDevServer {
           this.fastify.log.warn({
             msg: 'Missing platform query param',
             query: request.query,
+            method: request.method,
+            url: request.url,
           });
           reply.code(400).send();
         } else {

--- a/src/webpack/plugins/DevServerPlugin/DevServerPlugin.ts
+++ b/src/webpack/plugins/DevServerPlugin/DevServerPlugin.ts
@@ -3,6 +3,14 @@ import ReactRefreshPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import { WebpackPlugin } from '../../../types';
 import { DevServer, DevServerConfig } from '../../../server';
 
+type ExtractEntryStaticNormalized<E> = E extends () => Promise<infer U>
+  ? U
+  : E extends { [key: string]: any }
+  ? E
+  : never;
+
+type EntryStaticNormalized = ExtractEntryStaticNormalized<webpack.EntryNormalized>;
+
 /**
  * {@link DevServerPlugin} configuration options.
  */
@@ -64,6 +72,45 @@ export class DevServerPlugin implements WebpackPlugin {
       new ReactRefreshPlugin({
         overlay: false,
       }).apply(compiler);
+
+      // To avoid the problem from https://github.com/facebook/react/issues/20377
+      // we need to move React Refresh entry that `ReactRefreshPlugin` injects to evaluate right
+      // before the `WebpackHMRClient` and after `InitializeCore` which sets up React DevTools.
+      // Thanks to that the initialization order is correct:
+      // 0. Polyfills
+      // 1. `InitilizeCore` -> React DevTools
+      // 2. Rect Refresh Entry
+      // 3. `WebpackHMRClient`
+      const getAdjustedEntry = (entry: EntryStaticNormalized) => {
+        for (const key in entry) {
+          const { import: entryImports = [] } = entry[key];
+          const refreshEntryIndex = entryImports.findIndex((value) =>
+            /ReactRefreshEntry\.js/.test(value)
+          );
+          if (refreshEntryIndex >= 0) {
+            const refreshEntry = entryImports[refreshEntryIndex];
+            entryImports.splice(refreshEntryIndex, 1);
+
+            const hmrClientIndex = entryImports.findIndex((value) =>
+              /WebpackHMRClient\.js/.test(value)
+            );
+            entryImports.splice(hmrClientIndex, 0, refreshEntry);
+          }
+          entry[key].import = entryImports;
+        }
+
+        return entry;
+      };
+
+      if (typeof compiler.options.entry !== 'function') {
+        compiler.options.entry = getAdjustedEntry(compiler.options.entry);
+      } else {
+        const getEntry = compiler.options.entry;
+        compiler.options.entry = async () => {
+          const entry = await getEntry();
+          return getAdjustedEntry(entry);
+        };
+      }
     }
 
     let server: DevServer | undefined;

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -63,8 +63,6 @@ const {
 
 /**
  * Enable Hot Module Replacement with React Refresh in development.
- * Currently React Refresh breaks React Devtools (https://github.com/facebook/react/issues/20377)
- * so when using Flipper you might want to disable HMR.
  */
 const hmr = dev;
 


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Initialize React DevTools (as part of `InitializeCore.js`) before initializing React Refresh to avoid the issue listed here: [https://github.com/facebook/react/issues/20377](https://github.com/facebook/react/issues/20377).

### Test plan

1. Run application
2. Open Flipper
3. Check React DevTools - it should show React component tree
4. Make more change in source code, the app should apply the update and component tree inside React DevTools should be updated.
