### PR TITLE
feat: report dev server logs to Flipper

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -110,6 +110,12 @@ the end destination for all logs is `Reporter` instance — this is the place wh
 written to the terminal and/or file. The route that each log takes to get to the reporter instance
 will differ.
 
+The top-level `Reporter` instance will also try to broadcast logs to the connected Flipper instance
+under _React Native_ -> _Logs_ with tag `rnwt_<type>` where `type` can be `debug`, `info`, `warn`
+or `error`. Because of the Flipper tight integration with Metro all `react-native-webpack-toolkit`
+logs will be reported as `verbose` so make sure you sent the filter to include type `Verbose`
+and use searching to filter logs e.g. by typing `rnwt_debug`.
+
 ### Bundling with `(webpack-)bundle` command and Webpack CLI / Running with development server via Webpack CLI
 
 > Read as stack trace, from bottom to the top.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ __Check the base [`webpack.config.js`](./templates/webpack.config.js) template, 
 - [x] Reloading application from CLI
 - [x] Flipper support (tested features: Crash Reporter, Logs, Layout, Network, React DevTools)
 - [x] Hermes support
+- [x] Improved development server debugging with logs inside Flipper. 
 
 ### Planned features
 

--- a/src/server/DevServerProxy.ts
+++ b/src/server/DevServerProxy.ts
@@ -79,7 +79,7 @@ export class DevServerProxy extends BaseDevServer {
   /** Platform to worker mappings. */
   workers: Record<string, Promise<CompilerWorker>> = {};
   /** Reporter instance. */
-  reporter = new Reporter();
+  reporter = new Reporter({ wsEventsServer: this.wsEventsServer });
 
   /**
    * Constructs new `DevServerProxy`.

--- a/src/server/ws/WebSocketEventsServer.ts
+++ b/src/server/ws/WebSocketEventsServer.ts
@@ -153,6 +153,7 @@ export class WebSocketEventsServer extends WebSocketServer {
           msg: 'Failed to send broadcast to client',
           clientId,
           error,
+          _skipBroadcast: true,
         });
       }
     }


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

This PR allows to see the development server logs inside connected Flipper instance in addition to the terminal, so one would be able to inspect and better filter/search for the logging information for debugging purposes.

![Screenshot 2021-03-18 at 15 07 41](https://user-images.githubusercontent.com/17573635/111640154-34117600-87fc-11eb-877b-6f9b53cfbf20.png)

### Test plan

1. Start development server e.g. run `npx react-native webpack-start`
2. Open Flipper and go to _React Native_ -> `Logs`
3. Loop for `rnwt_<type>` logs.
