### PR TITLE
fix: add `enable` option to DevServer for disabling the plugin instead of passing `undefined`

### DIFF
--- a/examples/TesterApp/webpack.config.js
+++ b/examples/TesterApp/webpack.config.js
@@ -6,7 +6,7 @@ const {
   ReactNativeAssetsPlugin,
   LoggerPlugin,
   DevServerPlugin,
-  // DEFAULT_PORT,
+  DEFAULT_PORT,
   ReactNativeTargetPlugin,
 } = require('../..');
 
@@ -52,13 +52,16 @@ const {
 } = parseCliOptions({
   fallback: {
     /**
+     * Fallback to production when running with Webpack CLI.
+     */
+    mode: 'production',
+    /**
      * Make sure you always specify platform when running with Webpack CLI.
      * Alternatively you could use `process.env.PLATFORM` and run:
      * `PLATFORM=ios npx webpack-cli -c webpack.config.js`
      */
     platform: 'ios',
-    /** Uncomment to start development server when running with Webpack CLI. */
-    // devServer: { port: DEFAULT_PORT },
+    devServer: { port: DEFAULT_PORT },
   },
 });
 
@@ -66,6 +69,11 @@ const {
  * Enable Hot Module Replacement with React Refresh in development.
  */
 const hmr = dev;
+
+/**
+ * Enable development server in development mode.
+ */
+const devServerEnabled = dev;
 
 /**
  * Depending on your Babel configuration you might want to keep it.
@@ -196,9 +204,9 @@ module.exports = {
 
     /**
      * Runs development server when running with React Native CLI start command or if `devServer`
-     * was provided as s `fallback`. Passing `undefined` as 1st argument will disable the plugin.
+     * was provided as s `fallback`.
      */
-    new DevServerPlugin({ ...devServer, hmr }),
+    new DevServerPlugin({ enabled: devServerEnabled, hmr, ...devServer }),
 
     /**
      * Configures Source Maps.
@@ -223,7 +231,7 @@ module.exports = {
      */
     new LoggerPlugin({
       platform,
-      devServer: Boolean(devServer),
+      devServerEnabled,
       output: {
         console: true,
         /**

--- a/examples/TesterApp/webpack.config.js
+++ b/examples/TesterApp/webpack.config.js
@@ -206,7 +206,13 @@ module.exports = {
      * Runs development server when running with React Native CLI start command or if `devServer`
      * was provided as s `fallback`.
      */
-    new DevServerPlugin({ enabled: devServerEnabled, hmr, ...devServer }),
+     new DevServerPlugin({
+      enabled: devServerEnabled,
+      hmr,
+      context,
+      platform,
+      ...devServer,
+    }),
 
     /**
      * Configures Source Maps.

--- a/src/server/BaseDevServer.ts
+++ b/src/server/BaseDevServer.ts
@@ -15,7 +15,12 @@ import {
 /**
  * {@link BaseDevServer} configuration options.
  */
-export interface BaseDevServerConfig extends DevServerOptions {}
+export interface BaseDevServerConfig extends DevServerOptions {
+  /** Context in which all resolution happens. Usually it's project root directory. */
+  context: string;
+  /** Target application platform. */
+  platform: string;
+}
 
 /**
  * Base class for all Fastify-based servers.

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,10 +82,6 @@ export interface DevServerOptions {
   cert?: string;
   /** Path to certificate key when running server on HTTPS. */
   key?: string;
-  /** Context in which all resolution happens. Usually it's project root directory. */
-  context: string;
-  /** Target application platform. */
-  platform: string;
 }
 
 /**

--- a/src/webpack/plugins/LoggerPlugin.ts
+++ b/src/webpack/plugins/LoggerPlugin.ts
@@ -11,7 +11,7 @@ export interface LoggerPluginConfig {
   /** Target application platform. */
   platform: string;
   /** Whether development server is running/enabled. */
-  devServer?: boolean;
+  devServerEnabled?: boolean;
   /** Logging output config. */
   output?: {
     /** Whether to log to console. */
@@ -109,7 +109,7 @@ export class LoggerPlugin implements WebpackPlugin {
     // Make sure webpack-cli doesn't print stats by default.
     compiler.options.stats = 'none';
 
-    if (this.config.devServer) {
+    if (this.config.devServerEnabled) {
       new webpack.ProgressPlugin((percentage, message) => {
         const entry = this.createEntry('LoggerPlugin', 'info', [
           {
@@ -149,7 +149,7 @@ export class LoggerPlugin implements WebpackPlugin {
     });
 
     compiler.hooks.done.tap('LoggerPlugin', (stats) => {
-      if (this.config.devServer) {
+      if (this.config.devServerEnabled) {
         const { time, errors, warnings } = stats.toJson({
           timings: true,
           errors: true,

--- a/src/webpack/utils/parseCliOptions.ts
+++ b/src/webpack/utils/parseCliOptions.ts
@@ -39,7 +39,7 @@ export const DEFAULT_FALLBACK: WebpackOptionsWithoutPlatform = {
   outputPath: path.join(process.cwd(), 'dist'),
   assetsOutputPath: path.join(process.cwd(), 'dist'),
   outputFilename: 'index.bundle',
-  sourcemapFilename: 'index.bundle.map',
+  sourcemapFilename: '[file].map',
   context: process.cwd(),
   reactNativePath: path.join(process.cwd(), './node_modules/react-native'),
   minimize: false,
@@ -136,8 +136,6 @@ export function parseCliOptions(config: ParseCliOptionsConfig): WebpackOptions {
         https: args.https,
         cert: args.cert || undefined,
         key: args.key || undefined,
-        context: cliOptions.config.root,
-        platform: args.platform,
       },
     };
   }

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -6,7 +6,7 @@ const {
   ReactNativeAssetsPlugin,
   LoggerPlugin,
   DevServerPlugin,
-  // DEFAULT_PORT,
+  DEFAULT_PORT,
   ReactNativeTargetPlugin,
 } = require('react-native-webpack-toolkit');
 
@@ -52,13 +52,16 @@ const {
 } = parseCliOptions({
   fallback: {
     /**
+     * Fallback to production when running with Webpack CLI.
+     */
+    mode: 'production',
+    /**
      * Make sure you always specify platform when running with Webpack CLI.
      * Alternatively you could use `process.env.PLATFORM` and run:
      * `PLATFORM=ios npx webpack-cli -c webpack.config.js`
      */
     platform: 'ios',
-    /** Uncomment to start development server when running with Webpack CLI. */
-    // devServer: { port: DEFAULT_PORT },
+    devServer: { port: DEFAULT_PORT },
   },
 });
 
@@ -66,6 +69,11 @@ const {
  * Enable Hot Module Replacement with React Refresh in development.
  */
 const hmr = dev;
+
+/**
+ * Enable development server in development mode.
+ */
+const devServerEnabled = dev;
 
 /**
  * Depending on your Babel configuration you might want to keep it.
@@ -196,9 +204,9 @@ module.exports = {
 
     /**
      * Runs development server when running with React Native CLI start command or if `devServer`
-     * was provided as s `fallback`. Passing `undefined` as 1st argument will disable the plugin.
+     * was provided as s `fallback`.
      */
-    new DevServerPlugin({ ...devServer, hmr }),
+    new DevServerPlugin({ enabled: devServerEnabled, hmr, ...devServer }),
 
     /**
      * Configures Source Maps.
@@ -223,7 +231,7 @@ module.exports = {
      */
     new LoggerPlugin({
       platform,
-      devServer: Boolean(devServer),
+      devServerEnabled,
       output: {
         console: true,
         /**

--- a/templates/webpack.config.js
+++ b/templates/webpack.config.js
@@ -206,7 +206,13 @@ module.exports = {
      * Runs development server when running with React Native CLI start command or if `devServer`
      * was provided as s `fallback`.
      */
-    new DevServerPlugin({ enabled: devServerEnabled, hmr, ...devServer }),
+    new DevServerPlugin({
+      enabled: devServerEnabled,
+      hmr,
+      context,
+      platform,
+      ...devServer,
+    }),
 
     /**
      * Configures Source Maps.


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Summary

Add new option `enable` to `DevServerPlugin` to allow conditionally disable development server instead of passing `undefined` to `new DevServerPlugin(...)` call.

### Test plan

1. Create production bundle.
2. No `DevServerPlugin` change should be present inside the bundle (e.g. `__webpack_require__.p` - public path should be `''`)
