### PR TITLE
feat: add support for custom webpack location

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,5 +1,12 @@
+const path = require('path');
 const RnCliStartCommand = require('@react-native-community/cli/build/commands/start/start')
   .default;
+
+const webpackConfigOption = {
+  name: '--webpackConfig <path>',
+  description: 'Path to a Webpack config',
+  parse: (val) => path.resolve(val),
+};
 
 module.exports = {
   commands: [
@@ -9,13 +16,14 @@ module.exports = {
         {
           name: '--verbose',
           description: 'Enables verbose logging',
-        }
+        },
+        webpackConfigOption
       ),
       func: require('./dist/commands/bundle').bundle,
     },
     {
       name: 'webpack-start',
-      options: RnCliStartCommand.options,
+      options: RnCliStartCommand.options.concat(webpackConfigOption),
       description: RnCliStartCommand.description,
       func: require('./dist/commands/start').start,
     },

--- a/src/commands/bundle.ts
+++ b/src/commands/bundle.ts
@@ -17,7 +17,10 @@ import { getWebpackConfigPath } from './utils/getWebpackConfigPath';
  * @category CLI command
  */
 export function bundle(_: string[], config: Config, args: BundleArguments) {
-  const webpackConfigPath = getWebpackConfigPath(config.root);
+  const webpackConfigPath = getWebpackConfigPath(
+    config.root,
+    args.webpackConfig
+  );
   const cliOptions = JSON.stringify({
     config: {
       root: config.root,

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -19,7 +19,10 @@ import { getWebpackConfigPath } from './utils/getWebpackConfigPath';
  * @category CLI command
  */
 export function start(_: string[], config: Config, args: StartArguments) {
-  const webpackConfigPath = getWebpackConfigPath(config.root);
+  const webpackConfigPath = getWebpackConfigPath(
+    config.root,
+    args.webpackConfig
+  );
   const cliOptions: CliOptions = {
     config: {
       root: config.root,

--- a/src/commands/utils/getWebpackConfigPath.ts
+++ b/src/commands/utils/getWebpackConfigPath.ts
@@ -1,16 +1,22 @@
 import path from 'path';
 import fs from 'fs';
 
-export function getWebpackConfigPath(root: string) {
-  // Supports the same files as Webpack CLI.
-  const candidates = [
-    'webpack.config.js',
-    '.webpack/webpack.config.js',
-    '.webpack/webpackfile',
-  ];
+// Supports the same files as Webpack CLI.
+const DEFAULT_WEBPACK_CONFIG_LOCATIONS = [
+  'webpack.config.js',
+  '.webpack/webpack.config.js',
+  '.webpack/webpackfile',
+];
+
+export function getWebpackConfigPath(root: string, customPath?: string) {
+  const candidates = customPath
+    ? [customPath]
+    : DEFAULT_WEBPACK_CONFIG_LOCATIONS;
 
   for (const candidate of candidates) {
-    const filename = path.join(root, candidate);
+    const filename = path.isAbsolute(candidate)
+      ? candidate
+      : path.join(root, candidate);
     if (fs.existsSync(filename)) {
       return filename;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,8 @@ export interface CommonArguments {
   resetCache?: boolean;
   /** Whether to log additional debug messages. */
   verbose?: boolean;
+  /** Custom path to Webpack config. */
+  webpackConfig?: string;
 }
 
 /**


### PR DESCRIPTION
### Summary

Adds `--webpackConfig <path>` options to `webpack-start` and `webpack-bundle` commands.

### Test plan

1. Move/create Webpack config in non-default location eg `webpack-config.js`
2. Run `webpack-start`/`webpack-bundle` with `--webpackConfig ./webpack-config.js`
3. The code should not throw error
