### PR TITLE
Fix resolution of assets with scale

### DIFF
--- a/src/webpack/plugins/ReactNativeAssetsPlugin/ReactNativeAssetResolver.ts
+++ b/src/webpack/plugins/ReactNativeAssetsPlugin/ReactNativeAssetResolver.ts
@@ -123,7 +123,7 @@ export class ReactNativeAssetResolver {
 
             const basename = path.basename(requestPath);
             const name = basename.replace(/\.[^.]+$/, '');
-            const type = path.extname(requestPath);
+            const type = path.extname(requestPath).substring(1);
             const files = ((results as Array<string | Buffer>)?.filter(
               (result) => typeof result === 'string'
             ) ?? []) as string[];


### PR DESCRIPTION
### Summary

Importing assets in a single scale with `import file from './file.png'` works, but if the assets are named `file@1x.png` the resolver won't find them. The reason is that the scale mapper expects the `type` argument to be without a leading dot, but `path.extname()` will include it. 

This PR simply omits this dot. 

### Test plan

I've tested this locally with my project. 